### PR TITLE
Add --without-K to all files

### DIFF
--- a/src/ABTPredicate.agda
+++ b/src/ABTPredicate.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.List using (List; []; _∷_; length; map; foldl)
 open import Data.Nat using (ℕ; zero; suc; _+_; _<_; _≤_; _⊔_; z≤n; s≤s)

--- a/src/AbstractBindingTree.agda
+++ b/src/AbstractBindingTree.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K  #-}
 open import Agda.Primitive using (Level; lzero; lsuc)
 open import Data.Bool using (Bool; true; false; _∨_)
 open import Data.Empty using (⊥)

--- a/src/Fold.agda
+++ b/src/Fold.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.Empty using (⊥)
 open import Data.List using (List; []; _∷_) renaming (map to lmap)

--- a/src/FoldFoldFusion.agda
+++ b/src/FoldFoldFusion.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Empty.Irrelevant renaming (⊥-elim to ⊥-elimi)

--- a/src/FoldMapFusion.agda
+++ b/src/FoldMapFusion.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 {-
      Fusion of fold and map:
 

--- a/src/FoldPreserve.agda
+++ b/src/FoldPreserve.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 {---------------------------------
 
   Fold preserves any ABT predicate

--- a/src/GSubst.agda
+++ b/src/GSubst.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K  #-}
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Nat.Properties using (+-comm; +-assoc)
 open import Structures

--- a/src/GenericSubstitution.agda
+++ b/src/GenericSubstitution.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.Bool using (Bool; true; false; _∨_)
 open import Data.Empty.Irrelevant renaming (⊥-elim to ⊥-elimi)

--- a/src/ListAux.agda
+++ b/src/ListAux.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K --safe #-}
 open import Data.List using (List; []; _∷_; length; _++_)
 open import Data.List.Properties using (length-++; ++-assoc; ≡-dec)
 open import Data.Nat using (ℕ; zero; suc; _+_; _<_; _≤_; z≤n; s≤s; _≟_)

--- a/src/Map.agda
+++ b/src/Map.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Product using (_×_) renaming (_,_ to ⟨_,_⟩ )

--- a/src/MapFusion.agda
+++ b/src/MapFusion.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (ℕ; zero; suc)

--- a/src/MapPreserve.agda
+++ b/src/MapPreserve.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 {---------------------------
 
   Preservation of a predicate

--- a/src/Renaming.agda
+++ b/src/Renaming.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 {----------------------------------------------------------------------------
                              Renaming
  ---------------------------------------------------------------------------}
@@ -45,7 +46,7 @@ module WithOpSig (Op : Set) (sig : Op → List Sig)  where
                        ; var→val-suc-shift = λ {x} → refl }
 
   ren-up-seq : ∀ (k : ℕ) (ρ : Rename) → ↑ k ⨟ ρ ≡ drop k ρ
-  ren-up-seq k ρ rewrite up-seq k ρ | map-sub-id (drop k ρ) = refl
+  ren-up-seq k ρ = up-seq k ρ
 
   ren-cons-seq : ∀ x (ρ₁ ρ₂ : Rename) → (x • ρ₁) ⨟ ρ₂ ≡ (ρ₂) x • (ρ₁ ⨟ ρ₂)
   ren-cons-seq x ρ₁ ρ₂ rewrite cons-seq x ρ₁ ρ₂ = refl

--- a/src/ScopedTuple.agda
+++ b/src/ScopedTuple.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K --safe #-}
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (ℕ; zero; suc; _+_; _∸_)
 open import Data.Product using (_×_; proj₁; proj₂) renaming (_,_ to ⟨_,_⟩ )

--- a/src/Sig.agda
+++ b/src/Sig.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K --safe #-}
 open import Data.Nat using (ℕ; zero; suc)
 
 module Sig where

--- a/src/Structures.agda
+++ b/src/Structures.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K  #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (ℕ; zero; suc)

--- a/src/SubstPreserve.agda
+++ b/src/SubstPreserve.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 import ABTPredicate
 open import Data.List using (List; []; _∷_; length; _++_)
 open import Data.Nat using (ℕ; zero; suc)

--- a/src/Substitution.agda
+++ b/src/Substitution.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Data.List using (List; []; _∷_)
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Nat.Properties using (+-comm)
@@ -45,7 +46,7 @@ module ABTOps (Op : Set) (sig : Op → List Sig)  where
           ; quote-var→val₁ = λ x → refl ; quote-map = λ σ₂ v₁ → refl }
 
   sub-up-seq : ∀ k (σ : Subst) → ↑ k ⨟ σ ≡ drop k σ
-  sub-up-seq k σ rewrite up-seq k σ | map-sub-id (drop k σ) = refl
+  sub-up-seq k σ = up-seq k σ
 
   sub-cons-seq : ∀ x σ₁ σ₂ → (x • σ₁) ⨟ σ₂ ≡ ⟪ σ₂ ⟫ x • (σ₁ ⨟ σ₂)
   sub-cons-seq x σ₁ σ₂ rewrite cons-seq x σ₁ σ₂ = refl
@@ -54,7 +55,7 @@ module ABTOps (Op : Set) (sig : Op → List Sig)  where
   sub-head M σ = refl
 
   sub-tail : ∀ (M : ABT) (σ : Subst) → (↑ 1 ⨟ M • σ) ≡ σ
-  sub-tail M σ rewrite sub-up-seq 1 (M • σ) | drop-0 σ = refl
+  sub-tail M σ = sub-up-seq 1 (M • σ)
 
   sub-suc : ∀ (M : ABT) σ x → ⟪ M • σ ⟫ (` suc x) ≡ ⟪ σ ⟫ (` x)
   sub-suc M σ x = refl
@@ -63,7 +64,7 @@ module ABTOps (Op : Set) (sig : Op → List Sig)  where
   shift-eq x k = refl
 
   sub-idL : (σ : Subst) → id ⨟ σ ≡ σ
-  sub-idL σ rewrite sub-up-seq 0 σ | drop-0 σ = refl
+  sub-idL σ = sub-up-seq 0 σ
 
   sub-dist :  ∀ σ τ M → ((M • σ) ⨟ τ) ≡ ((⟪ τ ⟫ M) • (σ ⨟ τ))
   sub-dist σ τ M rewrite sub-cons-seq M σ τ = refl

--- a/src/Syntax.agda
+++ b/src/Syntax.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Data.List using (List)
 open import Data.Nat using (ℕ)
 

--- a/src/Var.agda
+++ b/src/Var.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K --safe #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.Nat using (ℕ; zero; suc; _<_; z≤n; s≤s; _+_)
 open import Data.Empty using (⊥)

--- a/src/WellScoped.agda
+++ b/src/WellScoped.agda
@@ -1,3 +1,4 @@
+{-# OPTIONS --without-K #-}
 open import Agda.Primitive using (Level; lzero; lsuc; _⊔_)
 open import Data.Empty.Irrelevant renaming (⊥-elim to ⊥-elimi)
 open import Data.Nat using (ℕ; zero; suc; _<_; _≤_; z≤n; s≤s; _+_; _≤?_)


### PR DESCRIPTION
This allows for the library to be used in more projects, and only requires minimal changes to a few of the proofs. It also paves the road for, in the future, possibly using --cubical so that we don't need extensionality as an axiom.