### PR TITLE
Added lemma "upshift by one and single subst is identity"

### DIFF
--- a/src/Substitution.agda
+++ b/src/Substitution.agda
@@ -186,7 +186,16 @@ module ABTOps (Op : Set) (sig : Op → List Sig)  where
 
   _[_] : ABT → ABT → ABT
   N [ M ] =  ⟪ subst-zero M ⟫ N
-  
+
+  subst-zero-↑1-id : ∀ M N
+    → ⟪ subst-zero M ⟫ (⟪ ↑ 1 ⟫ N) ≡ N
+  subst-zero-↑1-id M N =
+    begin
+    ⟪ subst-zero M ⟫ (⟪ ↑ 1 ⟫ N) ≡⟨ sub-sub {N} {↑ 1} {subst-zero M} ⟩
+    ⟪ ↑ 1 ⨟ (M • id) ⟫ N         ≡⟨ cong (λ □ → ⟪ □ ⟫ N) (sub-tail M _) ⟩
+    ⟪ id ⟫ N                      ≡⟨ sub-id ⟩
+    N ∎
+
   subst-zero-exts-cons : ∀{σ : Subst}{M : ABT} → ext σ ⨟ subst-zero M ≡ M • σ
   subst-zero-exts-cons {σ}{M} = begin
      ext σ ⨟ subst-zero M  ≡⟨ cong(λ □ → □  ⨟ subst-zero M)(exts-cons-shift σ) ⟩


### PR DESCRIPTION
I added the following lemma in `Substitution.agda`:
```Agda
subst-zero-↑1-id : ∀ M N → ⟪ subst-zero M ⟫ (⟪ ↑ 1 ⟫ N) ≡ N
```
This can be seen as the base case (about `subst-zero`), while the following lemma that I added a while ago (following a similar lemma in `Renaming.agda`) is the inductive case (about `ext`). Both lemmas are about how substitutions interact with upshift (the renaming `↑ 1`).
```Agda
sub-commute-↑1 : ∀ σ M → ⟪ ext σ ⟫ (⟪ ↑ 1 ⟫ M) ≡ ⟪ ↑ 1 ⟫ (⟪ σ ⟫ M)
```